### PR TITLE
Fixes to ansible appliance

### DIFF
--- a/overlay/usr/lib/inithooks/bin/setpass_key.py
+++ b/overlay/usr/lib/inithooks/bin/setpass_key.py
@@ -16,6 +16,7 @@ import getopt
 import subprocess
 from subprocess import PIPE
 import signal
+import pipes
 
 from dialog_wrapper import Dialog
 
@@ -66,7 +67,7 @@ def main():
         fatal(err)
 
     """use ssh-keygen to create an rsa key pair using the same password"""
-    subprocess.call(['su', username, '-c', 'ssh-keygen -q -b 4096 -t rsa -f $HOME/.ssh/id_rsa -N %s' % password])
+    subprocess.call(['su', username, '-c', 'ssh-keygen -q -b 4096 -t rsa -f $HOME/.ssh/id_rsa -N %s' % pipes.quote(password)])
     if err:
         fatal(err)
 

--- a/plan/main
+++ b/plan/main
@@ -8,6 +8,8 @@ libyaml-dev
 gcc                 /* packages needed for compiling pycrypto */
 make
 python-dev
+libffi-dev
+libssl-dev
 python-apt          /* allows ansible to manage apt packages */
 sudo                /* required to give ansible user root privileges */
 sshpass             /* required by ansible to script password entry */


### PR DESCRIPTION
Here are a couple of fixes to the ansible appliance. The first adds a couple of dev packages that are necessary when installing ansible via pip. The second uses the python pipes.quote to allow special characters in the ssh key password.
